### PR TITLE
Datacite 4.3

### DIFF
--- a/datacite/schema43.py
+++ b/datacite/schema43.py
@@ -58,7 +58,7 @@ def validate(data):
 
 @rules.rule('identifiers')
 def identifiers(root, values):
-    """Transform identifiers to alternateIdenftifiers and identifier."""
+    """Transform identifiers to alternateIdenfifiers and identifier."""
     """
     We assume there will only be 1 DOI identifier for the record.
     Any other identifiers are alternative identifiers.
@@ -85,7 +85,7 @@ def identifiers(root, values):
         #If we only have the DOI
         return doi
     else:
-        return (root,doi)
+        return root, doi
 
 
 def affiliations(root, values):
@@ -115,7 +115,7 @@ def givenname(root, value):
         root.append(E.givenName(val))
 
 
-def person_or_org_name(root, value, xml_tagname,json_tagname):
+def person_or_org_name(root, value, xml_tagname, json_tagname):
     """Extract creator/contributor name and it's 'nameType' attribute."""
     elem = E(xml_tagname, value[json_tagname])
     set_elem_attr(elem, 'nameType', value)

--- a/datacite/schema43.py
+++ b/datacite/schema43.py
@@ -90,13 +90,15 @@ def identifiers(root, values):
 
 def affiliations(root, values):
     """Extract affiliation."""
-    vals = values.get('affiliation', [])
+    vals = values.get('affiliations', [])
     for val in vals:
-        elem = E.affiliation(val['name'])
-        if val.get('affiliationIdentifier'):
-            elem.set('affiliationIdentifierScheme', val['affiliationIdentifierScheme'])
+        if val.get('affiliation'):
+            elem = E.affiliation(val['affiliation'])
+            # affiliationIdentifier metadata as Attributes (0-1 cardinality, instead of 0-n as list of objects)
             set_elem_attr(elem, 'affiliationIdentifier', val)
-        root.append(elem)
+            set_elem_attr(elem, 'affiliationIdentifierScheme', val)
+            set_elem_attr(elem, 'schemeURI', val)
+            root.append(elem)
 
 
 def familyname(root, value):

--- a/datacite/schemas/datacite-v4.3.json
+++ b/datacite/schemas/datacite-v4.3.json
@@ -22,26 +22,15 @@
             },
             "uniqueItems": true
         },
-        "affiliationIdentifiers": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "affiliationIdentifier": {"type": "string"},
-                    "affiliationIdentifierScheme": {"type": "string"},
-                    "schemeURI": {"type": "string", "format": "uri"}
-                },
-                "required": ["affiliationIdentifier", "affiliationIdentifierScheme"]
-            },
-            "uniqueItems": true
-        },
         "affiliations": {
             "type": "array",
             "items": {
                 "type": "object",
                 "properties": {
                     "affiliation": {"type": "string"},
-                    "affiliationIdentifier": {"$ref":"#/definitions/affiliationIdentifiers"}
+                    "affiliationIdentifier": {"type": "string"},
+                    "affiliationIdentifierScheme": {"type": "string"},
+                    "schemeURI": {"type": "string", "format": "uri"}
                 },
                 "required": ["affiliation"]
             },


### PR DESCRIPTION
This PR modifies schema43.py and the json schema 4.3 to set the cardinality of affiliationIdentifiers to 0-1 instead of 0-n.

NB: Tests are not implemented, but the initially forked version was not passing its own tests either... 
