### PR TITLE
fixed affiliation sections

### DIFF
--- a/datacite/schema43.py
+++ b/datacite/schema43.py
@@ -90,7 +90,7 @@ def identifiers(root, values):
 
 def affiliations(root, values):
     """Extract affiliation."""
-    vals = values.get('affiliation', [])
+    vals = values.get('affiliations', [])
     for val in vals:
         if val.get('name'):
             elem = E.affiliation(val['name'])

--- a/datacite/schema43.py
+++ b/datacite/schema43.py
@@ -88,9 +88,9 @@ def identifiers(root, values):
         return root, doi
 
 
-def affiliations(root, values):
+def affiliation(root, values):
     """Extract affiliation."""
-    vals = values.get('affiliations', [])
+    vals = values.get('affiliation', [])
     for val in vals:
         if val.get('name'):
             elem = E.affiliation(val['name'])
@@ -149,7 +149,7 @@ def creators(path, values):
         givenname(creator, value)
         familyname(creator, value)
         nameidentifiers(creator, value)
-        affiliations(creator, value)
+        affiliation(creator, value)
         root.append(creator)
 
     return root
@@ -225,7 +225,7 @@ def contributors(path, values):
         givenname(contributor, value)
         familyname(contributor, value)
         nameidentifiers(contributor, value)
-        affiliations(contributor, value)
+        affiliation(contributor, value)
         root.append(contributor)
 
     return root

--- a/datacite/schemas/datacite-v4.3.json
+++ b/datacite/schemas/datacite-v4.3.json
@@ -250,7 +250,7 @@
                     "givenName": {"type": "string"},
                     "familyName": {"type": "string"},
                     "nameIdentifiers": {"$ref": "#/definitions/nameIdentifiers"},
-                    "affiliations": {"$ref": "#/definitions/affiliation"},
+                    "affiliation": {"$ref": "#/definitions/affiliation"},
                     "lang": {"type": "string"}
                 },
                 "required": ["name"]
@@ -305,7 +305,7 @@
                     "givenName": {"type": "string"},
                     "familyName": {"type": "string"},
                     "nameIdentifiers": {"$ref": "#/definitions/nameIdentifiers"},
-                    "affiliations": {"$ref": "#/definitions/affiliation"},
+                    "affiliation": {"$ref": "#/definitions/affiliation"},
                     "lang": {"type": "string"}
                 },
                 "required": ["contributorType", "name"]

--- a/datacite/schemas/datacite-v4.3.json
+++ b/datacite/schemas/datacite-v4.3.json
@@ -35,7 +35,7 @@
                     "affiliationIdentifierScheme": {"type": "string"},
                     "schemeUri": {"type": "string", "format": "uri"}
                 },
-                "required": ["affiliation"]
+                "required": ["name"]
             },
             "uniqueItems": true
         },
@@ -250,7 +250,7 @@
                     "givenName": {"type": "string"},
                     "familyName": {"type": "string"},
                     "nameIdentifiers": {"$ref": "#/definitions/nameIdentifiers"},
-                    "affiliations": {"$ref": "#/definitions/affiliations"},
+                    "affiliations": {"$ref": "#/definitions/affiliation"},
                     "lang": {"type": "string"}
                 },
                 "required": ["name"]
@@ -305,7 +305,7 @@
                     "givenName": {"type": "string"},
                     "familyName": {"type": "string"},
                     "nameIdentifiers": {"$ref": "#/definitions/nameIdentifiers"},
-                    "affiliations": {"$ref": "#/definitions/affiliations"},
+                    "affiliations": {"$ref": "#/definitions/affiliation"},
                     "lang": {"type": "string"}
                 },
                 "required": ["contributorType", "name"]

--- a/datacite/schemas/datacite-v4.3.json
+++ b/datacite/schemas/datacite-v4.3.json
@@ -25,7 +25,7 @@
             },
             "uniqueItems": true
         },
-        "affiliation": {
+        "affiliations": {
             "type": "array",
             "items": {
                 "type": "object",
@@ -250,7 +250,7 @@
                     "givenName": {"type": "string"},
                     "familyName": {"type": "string"},
                     "nameIdentifiers": {"$ref": "#/definitions/nameIdentifiers"},
-                    "affiliation": {"$ref": "#/definitions/affiliation"},
+                    "affiliation": {"$ref": "#/definitions/affiliations"},
                     "lang": {"type": "string"}
                 },
                 "required": ["name"]
@@ -305,7 +305,7 @@
                     "givenName": {"type": "string"},
                     "familyName": {"type": "string"},
                     "nameIdentifiers": {"$ref": "#/definitions/nameIdentifiers"},
-                    "affiliation": {"$ref": "#/definitions/affiliation"},
+                    "affiliation": {"$ref": "#/definitions/affiliations"},
                     "lang": {"type": "string"}
                 },
                 "required": ["contributorType", "name"]


### PR DESCRIPTION
The inclusion of affiliations didn't work with the current version of branch `datacite-4.3`. 

The schema had validation problems (using json_schema validation tools): 
* in `creators` and `contributors`, the schema was referring to `"#/definitions/affiliation"` which doesn't exist. The correct reference is `"#/definitions/affiliations"`
* in `/definitions/affiliations`, the `required` option was set to `affiliation` instead of `name`

I also updated the corresponding `datacite-4.3.py` script, since it was expecting elements named `affiliation` instead of `affiliations` in the `creator` and `contributor` sections. 

With those fixes, I can build nice Datacite-4.3 compliant XML metadata files including affiliations. 